### PR TITLE
fix: 修复输入时候频繁刷新侧栏目录树问题

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,12 @@ registerPlugin({
   name: extensionName,
   register (ctx) {
     ctx.statusBar.tapMenus(menus => {
-      docsify.check(ctx)
       menus['status-bar-tool']?.list?.push({
         id: extensionName,
         type: 'normal',
         title: i18n.t('gen_docsify'),
         onClick: async () => {
+          await docsify.check(ctx)
           const gen = await ctx.ui.useModal().confirm({
             component: DocsifyGenerator
           })


### PR DESCRIPTION
yn 每次输入内容更新时候会更新状态栏菜单，间接的调用了 check 方法，check 方法刷新了侧栏目录，导致开销比较大。因此改为在点击菜单后才刷新